### PR TITLE
feat(oc-go-cc): add cc-go with auto-managed proxy and quality-first model routing

### DIFF
--- a/claude/.claude/.env.tpl
+++ b/claude/.claude/.env.tpl
@@ -1,1 +1,2 @@
 BRAVE_API_KEY=op://Dev/Brave/api_key
+OC_GO_CC_API_KEY=op://Dev/Opencode/api_key

--- a/config/.config/oc-go-cc/config.json
+++ b/config/.config/oc-go-cc/config.json
@@ -1,0 +1,139 @@
+{
+  "api_key": "${OC_GO_CC_API_KEY}",
+  "host": "127.0.0.1",
+  "port": 3456,
+  "hot_reload": false,
+  "enable_streaming_scenario_routing": false,
+  "models": {
+    "background": {
+      "provider": "opencode-go",
+      "model_id": "kimi-k2.6",
+      "temperature": 0.1,
+      "max_tokens": 4096
+    },
+    "default": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.1,
+      "max_tokens": 8192,
+      "reasoning_effort": "max",
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "long_context": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.1,
+      "max_tokens": 16384,
+      "context_threshold": 80000,
+      "reasoning_effort": "max",
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "think": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.1,
+      "max_tokens": 16384,
+      "reasoning_effort": "max",
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "complex": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.1,
+      "max_tokens": 16384,
+      "reasoning_effort": "max",
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "fast": {
+      "provider": "opencode-go",
+      "model_id": "kimi-k2.6",
+      "temperature": 0.1,
+      "max_tokens": 4096
+    }
+  },
+  "fallbacks": {
+    "background": [
+      { "provider": "opencode-go", "model_id": "kimi-k2.5" },
+      { "provider": "opencode-go", "model_id": "qwen3.6-plus" }
+    ],
+    "default": [
+      {
+        "provider": "opencode-go",
+        "model_id": "glm-5.1",
+        "temperature": 0.1,
+        "max_tokens": 8192
+      },
+      {
+        "provider": "opencode-go",
+        "model_id": "deepseek-v4-flash",
+        "temperature": 0.1,
+        "max_tokens": 8192,
+        "reasoning_effort": "max",
+        "thinking": {
+          "type": "enabled"
+        }
+      }
+    ],
+    "long_context": [
+      { "provider": "opencode-go", "model_id": "minimax-m2.7" },
+      {
+        "provider": "opencode-go",
+        "model_id": "deepseek-v4-flash",
+        "temperature": 0.1,
+        "max_tokens": 16384,
+        "reasoning_effort": "max",
+        "thinking": {
+          "type": "enabled"
+        }
+      }
+    ],
+    "think": [
+      {
+        "provider": "opencode-go",
+        "model_id": "glm-5.1",
+        "temperature": 0.1,
+        "max_tokens": 16384
+      },
+      { "provider": "opencode-go", "model_id": "glm-5" }
+    ],
+    "complex": [
+      {
+        "provider": "opencode-go",
+        "model_id": "glm-5.1",
+        "temperature": 0.1,
+        "max_tokens": 16384
+      },
+      {
+        "provider": "opencode-go",
+        "model_id": "deepseek-v4-flash",
+        "temperature": 0.1,
+        "max_tokens": 16384,
+        "reasoning_effort": "max",
+        "thinking": {
+          "type": "enabled"
+        }
+      }
+    ],
+    "fast": [
+      { "provider": "opencode-go", "model_id": "kimi-k2.5" },
+      { "provider": "opencode-go", "model_id": "qwen3.6-plus" }
+    ]
+  },
+  "opencode_go": {
+    "base_url": "https://opencode.ai/zen/go/v1/chat/completions",
+    "anthropic_base_url": "https://opencode.ai/zen/go/v1/messages",
+    "timeout_ms": 300000
+  },
+  "logging": {
+    "level": "info",
+    "requests": true
+  }
+}

--- a/config/.config/zsh/plugins/alias.plugin.zsh
+++ b/config/.config/zsh/plugins/alias.plugin.zsh
@@ -28,5 +28,18 @@ alias https='http --default-scheme=https'
 alias cc='op run --no-masking --env-file=$HOME/.claude/.env.tpl -- claude'
 alias cc-yolo='cc --enable-auto-mode'
 alias cc-discord='cc --channels plugin:discord@claude-plugins-official --dangerously-skip-permissions'
-
 alias claude-yolo='claude --enable-auto-mode'
+
+# oc-go-cc
+cc-go() {
+  (
+    local started=0
+    if [[ "$(oc-go-cc status 2>&1)" == *"not running"* ]]; then
+      oc-go-cc serve -b || exit 1
+      started=1
+    fi
+    trap '(( started )) && oc-go-cc stop >/dev/null 2>&1' EXIT INT TERM
+    ANTHROPIC_BASE_URL=http://127.0.0.1:3456 ANTHROPIC_AUTH_TOKEN=unused \
+      op run --no-masking --env-file=$HOME/.claude/.env.tpl -- claude
+  )
+}


### PR DESCRIPTION
## Summary

- `cc-go` zsh 関数を追加。`oc-go-cc` プロキシを自動起動/停止しつつ、`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` を仕込んで `claude` を起動する。
- `config/.config/oc-go-cc/config.json` を品質特化チューニング（`deepseek-v4-pro` + `reasoning_effort:max` + `thinking:enabled` を主軸）で追加。
- `claude/.claude/.env.tpl` に `OC_GO_CC_API_KEY` の 1Password 参照を追加。

## なにが変わるか

| 項目 | Before | After |
|---|---|---|
| OpenCode Go 連携 | 無し | `cc-go` 一発で proxy + claude 起動 |
| proxy ライフサイクル | 手動 `serve` / `stop` | `cc-go` が `status` チェック → `serve -b` → 終了時 `stop`（既存稼働は巻き込まない）|
| モデル選定 | 旧コスト寄り設定（`kimi-k2.6` default 等）| `deepseek-v4-pro` を default/long_context/think/complex に投入、品質最大化 |
| API Key 管理 | 無し | `op run --env-file` 経由で 1Password から注入 |

## モデル設定の意図

[oc-go-cc/MODELS.md](https://github.com/samueltuyizere/oc-go-cc/blob/main/MODELS.md) の評価をベースに以下の選定:

| Scenario | Primary | 一次フォールバック | 採用理由 |
|---|---|---|---|
| `default` | `deepseek-v4-pro` (thinking) | `glm-5.1` | ★★★★★ / 1M ctx / agentic 最強 |
| `long_context` | `deepseek-v4-pro` (thinking) | `minimax-m2.7` | minimax(★★) を退避し品質を確保 |
| `think` | `deepseek-v4-pro` (thinking) | `glm-5.1` | `reasoning_effort:max` で多段推論強制 |
| `complex` | `deepseek-v4-pro` (thinking) | `glm-5.1` | アーキ判断は thinking 効果が大きい |
| `background` | `kimi-k2.6` | `kimi-k2.5` | 単純操作でも構文/意図解釈ミスを避けたい |
| `fast` | `kimi-k2.6` | `kimi-k2.5` | TTFT より品質優先 |

`temperature: 0.1` 統一でコーディング再現性を担保。`max_tokens` は thinking 用に余裕を持たせて 8192〜16384。

---

## macOS インストール手順

### 0. 前提

- macOS（Apple Silicon / Intel）
- [Homebrew](https://brew.sh/) インストール済み
- [1Password CLI (`op`)](https://developer.1password.com/docs/cli/get-started/) インストール済みかつサインイン済み（`cc` / `cc-go` が `op run --env-file` 経由で起動するため必須）
- このリポジトリが `make init` 済みで stow が走っている状態
- OpenCode Go サブスクリプション（$5/月〜、API Key を発行できること）
  - 参考: https://opencode.ai/docs/go/

### 1. `oc-go-cc` のインストール

```bash
brew tap samueltuyizere/tap
brew install oc-go-cc

# 動作確認
oc-go-cc --version
oc-go-cc models   # OpenCode Go から提供されるモデル一覧
```

> Homebrew 以外で入れたい場合は [INSTALLATION.md](https://github.com/samueltuyizere/oc-go-cc/blob/main/INSTALLATION.md) 参照。

### 2. OpenCode Go API Key を 1Password に登録

1Password 内に以下のアイテムを作成（`op://Dev/Opencode/api_key` で参照する想定）:

| Vault | Item | Field | Value |
|---|---|---|---|
| `Dev` | `Opencode` | `api_key` | `sk-opencode-...`（OpenCode 管理画面で発行）|

`.env.tpl` 側は本 PR で以下を追加済み:

```dotenv
OC_GO_CC_API_KEY=op://Dev/Opencode/api_key
```

別パスを使いたい場合は `claude/.claude/.env.tpl` の値を書き換えてください。

```bash
# 1Password CLI でアイテムが見えるか確認
op read "op://Dev/Opencode/api_key"
```

### 3. config の配置

本 PR が `config/.config/oc-go-cc/config.json` を追加します。`make init`（stow 経由）で `~/.config/oc-go-cc/config.json` にシンボリックリンクが張られます:

```bash
make init   # 既に init 済みなら不要
ls -l ~/.config/oc-go-cc/config.json
# -> リポジトリ内ファイルへの symlink になっていればOK

# 設定を検証
oc-go-cc validate
```

`config.json` 内の `api_key` は `${OC_GO_CC_API_KEY}` 補間になっているので、シェル環境変数として `OC_GO_CC_API_KEY` を渡す必要があります。`cc-go` は `op run --env-file=$HOME/.claude/.env.tpl` で自動的にこれを注入します。

### 4. シェル設定の再読み込み

```bash
exec zsh
type cc-go
# -> "cc-go is a shell function ..." が出ればロード済み
```

### 5. 起動

```bash
cc-go
```

挙動:

1. `oc-go-cc status` を確認
2. "Server is not running" なら `oc-go-cc serve -b` でバックグラウンド起動
3. `ANTHROPIC_BASE_URL=http://127.0.0.1:3456` / `ANTHROPIC_AUTH_TOKEN=unused` を渡しつつ `op run` 経由で `claude` 起動
4. `claude` 終了 / Ctrl+C / SIGTERM のいずれでも `oc-go-cc stop` を自動実行（自身が起動した場合のみ）

### 6. 動作確認

```bash
# 別ターミナルで proxy 経由のリクエストを観察
oc-go-cc status
tail -f ~/.config/oc-go-cc/oc-go-cc.log  # 環境による
```

`cc-go` で起動した `claude` 内でクエリすると、ログに OpenCode Go 側エンドポイント (`opencode.ai/zen/go/v1/...`) への転送が確認できます。

### トラブルシュート

| 症状 | 原因 / 対処 |
|---|---|
| `oc-go-cc: command not found` | `brew install oc-go-cc` を実行。`brew doctor` で PATH を確認 |
| `cc-go` 起動後すぐ落ちる | `op` セッション切れ。`op signin` してリトライ |
| `Server is not running` から先に進まない | `oc-go-cc serve` を手動で実行してエラー出力を確認。多くは `OC_GO_CC_API_KEY` 未設定 |
| 401 / 403 が返る | OpenCode Go の API Key 失効。OpenCode Go ダッシュボードで再発行し 1Password を更新 |
| 既存 `oc-go-cc serve` を巻き込んでほしくない | 仕様: 既に `status` が "running" の場合は `cc-go` 終了時に `stop` を呼ばない設計 |
| モデル設定を変えたい | `config/.config/oc-go-cc/config.json` を編集 → `oc-go-cc stop && oc-go-cc serve -b`（`hot_reload:false`）|

## Test plan

- [x] `brew install samueltuyizere/tap/oc-go-cc` でインストールできる
- [x] `op read "op://Dev/Opencode/api_key"` で API Key が解決できる
- [x] `make init` 後 `~/.config/oc-go-cc/config.json` が symlink として存在する
- [x] `oc-go-cc validate` が成功する
- [x] `exec zsh` 後 `type cc-go` が関数として認識される
- [x] `cc-go` 起動 → `claude` プロンプトが出る
- [x] 別ターミナルで `oc-go-cc status` が "running" になる
- [x] `claude` 終了後、`oc-go-cc status` が "not running" に戻る
- [x] 事前に手動で `oc-go-cc serve -b` してから `cc-go` を実行し、`claude` 終了後も `status` が "running" のまま（既存セッションを巻き込まない）
- [x] long context / think / complex / 通常クエリでそれぞれ意図したモデルがログに出る