### PR TITLE
feat(cooldown): add dependency cooldown configs for npm/pnpm/yarn/bun

### DIFF
--- a/config/.config/.bunfig.toml
+++ b/config/.config/.bunfig.toml
@@ -1,0 +1,4 @@
+# bun dependency cooldown: 7 日 = 604800 秒
+# 単位: 秒 / 対応: bun v1.3+
+[install]
+minimumReleaseAge = 604800

--- a/config/.config/npm/npmrc
+++ b/config/.config/npm/npmrc
@@ -1,0 +1,3 @@
+# npm dependency cooldown: 公開から 7 日以上経過したバージョンのみインストール許可
+# 単位: 日 / 対応: npm v11.10.0+
+min-release-age=7

--- a/config/.config/pnpm/config.yaml
+++ b/config/.config/pnpm/config.yaml
@@ -1,0 +1,3 @@
+# pnpm dependency cooldown: 7 日 = 10080 分
+# 単位: 分 / 対応: pnpm v10.16.0+
+minimumReleaseAge: 10080

--- a/config/.config/yarn/yarnrc.yml
+++ b/config/.config/yarn/yarnrc.yml
@@ -1,0 +1,3 @@
+# Yarn Berry dependency cooldown: 7 日 = 10080 分
+# 単位: 分 / 対応: yarn v4.10.0+
+npmMinimalAgeGate: 10080

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -35,6 +35,11 @@ export GOPATH="$XDG_DATA_HOME/go"
 export DENO_INSTALL="$XDG_DATA_HOME/deno"
 export DENO_INSTALL_ROOT="$DENO_INSTALL"
 
+### Node ecosystem (XDG override) ###
+# npm / Yarn Berry は XDG ネイティブ非対応のため設定ファイルのパスを上書き
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
+export YARN_RC_FILENAME="$XDG_CONFIG_HOME/yarn/yarnrc.yml"
+
 ### Java ###
 export SDKMAN_DIR="$XDG_DATA_HOME/sdkman"
 


### PR DESCRIPTION
## Summary

サプライチェーン攻撃対策として、公開から **7 日経過したパッケージのみ**インストールを許可する dependency cooldown 設定を 4 つのパッケージマネージャに追加。
非 XDG 対応のツールは `.zshenv` で環境変数を上書きし、設定ファイルを `~/.config` 配下に統一配置。

## 変更内容

### 設定ファイル新規追加

| ファイル | キー | 単位 | 対応バージョン |
|---|---|---|---|
| `config/.config/npm/npmrc` | `min-release-age=7` | 日 | npm v11.10.0+ |
| `config/.config/pnpm/config.yaml` | `minimumReleaseAge: 10080` | 分 | pnpm v10.16.0+ |
| `config/.config/yarn/yarnrc.yml` | `npmMinimalAgeGate: 10080` | 分 | yarn berry v4.10.0+ |
| `config/.config/.bunfig.toml` | `minimumReleaseAge = 604800` | 秒 | bun v1.3+ |

### `zsh/.zshenv` への環境変数追加

npm / Yarn Berry は XDG ネイティブ非対応のため、ユーザー設定ファイルのパスを XDG 配下に上書き。

\`\`\`sh
export NPM_CONFIG_USERCONFIG=\"\$XDG_CONFIG_HOME/npm/npmrc\"
export YARN_RC_FILENAME=\"\$XDG_CONFIG_HOME/yarn/yarnrc.yml\"
\`\`\`

pnpm と bun は \`XDG_CONFIG_HOME\` をネイティブで参照するため env 不要。

### 対象外

- **Yarn v1 (Classic)**: ネイティブ非対応（メンテナンスモード）。\`cache-min\` での代替は別物のためスコープ外。
- **Deno**: グローバル設定が存在せず \`deno.json\` でプロジェクト単位設定が必要なため、別途プロジェクトテンプレート側で対応する想定。

## 注意点

- mise 管理下の Node 22 同梱の npm は v10 系の可能性があり、その場合 npm の設定は無視される（pnpm/bun は問題なし）。必要に応じて \`mise use -g npm@latest\` 等で npm 単体の更新を検討。
- yarn は mise 管理外。corepack 経由で yarn berry を有効化したときに初めて設定が効く。先回りで配置のみ実施。

## Test plan

- [x] \`make install-check\` で stow ドライランが衝突なく完走することを確認
- [ ] \`make install\` 実行後、新シェルで以下を確認
  - [ ] \`npm config get min-release-age\` → \`7\`
  - [ ] \`pnpm config get minimumReleaseAge\` → \`10080\`
  - [ ] \`bun pm\` 系コマンド実行時に \`~/.config/.bunfig.toml\` が読まれること
  - [ ] \`env | grep -E 'NPM_CONFIG_USERCONFIG|YARN_RC_FILENAME'\` で env が反映されること