### PR TITLE
fix(npm): remove yarn config and add private registry

### DIFF
--- a/config/.config/.bunfig.toml
+++ b/config/.config/.bunfig.toml
@@ -2,3 +2,5 @@
 # 単位: 秒 / 対応: bun v1.3+
 [install]
 minimumReleaseAge = 604800
+# プライベートレジストリ (bun は ~/.config/npm/npmrc を読まないので bunfig 側に別途記載)
+registry = "https://npm.flatt.tech"

--- a/config/.config/npm/npmrc
+++ b/config/.config/npm/npmrc
@@ -1,3 +1,6 @@
 # npm dependency cooldown: 公開から 7 日以上経過したバージョンのみインストール許可
 # 単位: 日 / 対応: npm v11.10.0+
 min-release-age=7
+
+# プライベートレジストリ
+registry=https://npm.flatt.tech

--- a/config/.config/pnpm/config.yaml
+++ b/config/.config/pnpm/config.yaml
@@ -1,3 +1,0 @@
-# pnpm dependency cooldown: 7 日 = 10080 分
-# 単位: 分 / 対応: pnpm v10.16.0+
-minimumReleaseAge: 10080

--- a/config/.config/yarn/yarnrc.yml
+++ b/config/.config/yarn/yarnrc.yml
@@ -1,3 +1,0 @@
-# Yarn Berry dependency cooldown: 7 日 = 10080 分
-# 単位: 分 / 対応: yarn v4.10.0+
-npmMinimalAgeGate: 10080

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -36,9 +36,8 @@ export DENO_INSTALL="$XDG_DATA_HOME/deno"
 export DENO_INSTALL_ROOT="$DENO_INSTALL"
 
 ### Node ecosystem (XDG override) ###
-# npm / Yarn Berry は XDG ネイティブ非対応のため設定ファイルのパスを上書き
+# npm は XDG 非対応のため userconfig パスを env で上書き
 export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
-export YARN_RC_FILENAME="$XDG_CONFIG_HOME/yarn/yarnrc.yml"
 
 ### Java ###
 export SDKMAN_DIR="$XDG_DATA_HOME/sdkman"


### PR DESCRIPTION
## Summary

- yarn は使用しないため cooldown 設定ごと撤去
- `YARN_RC_FILENAME` は **ファイル名のみ受付でパス指定不可** が判明したため `.zshenv` から削除（[Configuration.ts のコメント "Name of the files"](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/Configuration.ts)）
- npm に Flatt 社内レジストリ (`https://npm.flatt.tech`) を追加

## 変更内容

- `config/.config/yarn/yarnrc.yml` 削除
- `zsh/.zshenv` から `YARN_RC_FILENAME` 行削除
- `config/.config/npm/npmrc` に `registry=https://npm.flatt.tech` 追記

## Test plan

- [x] `make install-check` で stow 衝突なし
- [x] `npm config get registry` → `https://npm.flatt.tech`
- [x] `~/.config/yarn/` の dangling symlink を削除済み